### PR TITLE
Implement machine and worker search modals

### DIFF
--- a/src/components/BuscadorMaquina.js
+++ b/src/components/BuscadorMaquina.js
@@ -1,0 +1,50 @@
+import { useEffect, useState } from "react";
+import { API_BASE_URL } from "../api";
+
+export default function BuscadorMaquina({ onSelect, onClose }) {
+  const [maquinas, setMaquinas] = useState([]);
+  const [filtro, setFiltro] = useState("");
+
+  useEffect(() => {
+    fetch(`${API_BASE_URL}/maquinas`)
+      .then(res => res.json())
+      .then(setMaquinas)
+      .catch(err => console.error("Error al obtener máquinas:", err));
+  }, []);
+
+  const filtradas = maquinas.filter(m =>
+    m.tipo?.toLowerCase().includes(filtro.toLowerCase())
+  );
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50">
+      <div className="bg-white p-6 rounded-lg w-full max-w-lg shadow-lg">
+        <h2 className="text-lg font-semibold mb-4">Buscar máquina</h2>
+        <input
+          type="text"
+          placeholder="Filtrar por tipo"
+          value={filtro}
+          onChange={e => setFiltro(e.target.value)}
+          className="border px-3 py-1 rounded w-full mb-4"
+        />
+        <div className="max-h-60 overflow-y-auto">
+          {filtradas.map(m => (
+            <div key={m.id} className="flex justify-between items-center border-b py-1">
+              <span>{m.nombre} - {m.tipo}</span>
+              <button
+                onClick={() => { onSelect(m); onClose(); }}
+                className="px-2 py-1 text-sm bg-blue-600 text-white rounded"
+              >
+                Seleccionar
+              </button>
+            </div>
+          ))}
+        </div>
+        <div className="flex justify-end mt-4">
+          <button onClick={onClose} className="px-4 py-2 rounded bg-gray-300 hover:bg-gray-400">Cerrar</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/BuscadorTrabajador.js
+++ b/src/components/BuscadorTrabajador.js
@@ -1,0 +1,47 @@
+import { useEffect, useState } from "react";
+import { API_BASE_URL } from "../api";
+
+export default function BuscadorTrabajador({ onSelect, onClose }) {
+  const [trabajadores, setTrabajadores] = useState([]);
+  const [seleccion, setSeleccion] = useState(null);
+
+  useEffect(() => {
+    fetch(`${API_BASE_URL}/trabajadores`)
+      .then(res => res.json())
+      .then(setTrabajadores)
+      .catch(err => console.error("Error al obtener trabajadores:", err));
+  }, []);
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50">
+      <div className="bg-white p-6 rounded-lg w-full max-w-md shadow-lg">
+        <h2 className="text-lg font-semibold mb-4">Seleccionar trabajador</h2>
+        <div className="max-h-60 overflow-y-auto mb-4">
+          {trabajadores.map(t => (
+            <label key={t.id} className="flex items-center gap-2 border-b py-1">
+              <input
+                type="radio"
+                name="trabajador"
+                value={t.id}
+                checked={seleccion?.id === t.id}
+                onChange={() => setSeleccion(t)}
+              />
+              {t.nombre}
+            </label>
+          ))}
+        </div>
+        <div className="flex justify-end gap-2">
+          <button onClick={onClose} className="px-4 py-2 rounded bg-gray-300 hover:bg-gray-400">Cancelar</button>
+          <button
+            onClick={() => { if (seleccion) { onSelect(seleccion); onClose(); } }}
+            className="px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-700"
+            disabled={!seleccion}
+          >
+            Guardar selección
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/EditarAsignacion.js
+++ b/src/components/EditarAsignacion.js
@@ -1,23 +1,31 @@
 
 
 import { useState } from "react";
-
-const trabajadoresDisponibles = ["Carlos Pérez", "Juan Pérez", "Laura Gómez", "Mario Díaz"];
+import BuscadorMaquina from "./BuscadorMaquina";
+import BuscadorTrabajador from "./BuscadorTrabajador";
 
 export default function EditarAsignacion({ recursosIniciales, onClose, onSave }) {
-  const [recursos, setSesiones] = useState(recursosIniciales);
+  const [recursos, setRecursos] = useState(
+    recursosIniciales.map(r => ({
+      maquina: r.maquina || null,
+      trabajador: r.trabajador || null,
+      completado: r.cantidadProducida || 0,
+      asignado: r.cantidadRequerida || 0,
+    }))
+  );
+  const [indiceMaquina, setIndiceMaquina] = useState(null);
+  const [indiceTrabajador, setIndiceTrabajador] = useState(null);
 
   const handleChange = (index, field, value) => {
     const nuevos = [...recursos];
     nuevos[index][field] = value;
-    setSesiones(nuevos);
+    setRecursos(nuevos);
   };
 
   const agregarRecurso = () => {
-    setSesiones([...recursos, {
-      maquina: "",
-      trabajador: trabajadoresDisponibles[0],
-      referencia: recursos[0]?.referencia || "N/A",
+    setRecursos([...recursos, {
+      maquina: null,
+      trabajador: null,
       completado: 0,
       asignado: 0,
     }]);
@@ -33,7 +41,6 @@ export default function EditarAsignacion({ recursosIniciales, onClose, onSave })
               <tr>
                 <th className="px-4 py-2 border-r">Máquina</th>
                 <th className="px-4 py-2 border-r">Trabajador</th>
-                <th className="px-4 py-2 border-r">Referencia</th>
                 <th className="px-4 py-2 border-r">Cantidad completada</th>
                 <th className="px-4 py-2">Cantidad asignada</th>
               </tr>
@@ -42,19 +49,45 @@ export default function EditarAsignacion({ recursosIniciales, onClose, onSave })
               {recursos.map((r, i) => (
                 <tr key={i} className="border-t">
                   <td className="px-4 py-2 border-r">
-                    <input type="text" value={r.maquina} onChange={e => handleChange(i, "maquina", e.target.value)} className="w-full border px-2 py-1 rounded" />
+                    <div className="flex">
+                      <input
+                        type="text"
+                        value={r.maquina?.nombre || ""}
+                        readOnly
+                        className="w-full border px-2 py-1 rounded-l"
+                      />
+                      <button
+                        onClick={() => setIndiceMaquina(i)}
+                        className="px-2 bg-gray-200 rounded-r"
+                      >
+                        🔍
+                      </button>
+                    </div>
                   </td>
                   <td className="px-4 py-2 border-r">
-                    <select value={r.trabajador} onChange={e => handleChange(i, "trabajador", e.target.value)} className="w-full border px-2 py-1 rounded">
-                      {trabajadoresDisponibles.map(t => (
-                        <option key={t} value={t}>{t}</option>
-                      ))}
-                    </select>
+                    <div className="flex">
+                      <input
+                        type="text"
+                        value={r.trabajador?.nombre || ""}
+                        readOnly
+                        className="w-full border px-2 py-1 rounded-l"
+                      />
+                      <button
+                        onClick={() => setIndiceTrabajador(i)}
+                        className="px-2 bg-gray-200 rounded-r"
+                      >
+                        🔍
+                      </button>
+                    </div>
                   </td>
-                  <td className="px-4 py-2 border-r">{r.referencia}</td>
                   <td className="px-4 py-2 border-r">{r.completado}</td>
                   <td className="px-4 py-2">
-                    <input type="number" value={r.asignado} onChange={e => handleChange(i, "asignado", parseInt(e.target.value))} className="w-full border px-2 py-1 rounded" />
+                    <input
+                      type="number"
+                      value={r.asignado}
+                      onChange={e => handleChange(i, "asignado", parseInt(e.target.value))}
+                      className="w-full border px-2 py-1 rounded"
+                    />
                   </td>
                 </tr>
               ))}
@@ -71,6 +104,19 @@ export default function EditarAsignacion({ recursosIniciales, onClose, onSave })
           <button onClick={() => onSave(recursos)} className="px-4 py-2 rounded bg-green-600 text-white hover:bg-green-700">Guardar cambios</button>
         </div>
       </div>
+      {indiceMaquina !== null && (
+        <BuscadorMaquina
+          onSelect={(m) => handleChange(indiceMaquina, "maquina", m)}
+          onClose={() => setIndiceMaquina(null)}
+        />
+      )}
+      {indiceTrabajador !== null && (
+        <BuscadorTrabajador
+          onSelect={(t) => handleChange(indiceTrabajador, "trabajador", t)}
+          onClose={() => setIndiceTrabajador(null)}
+        />
+      )}
     </div>
-  );
+  </div>
+ );
 }

--- a/src/components/EditarAsignacion.js
+++ b/src/components/EditarAsignacion.js
@@ -1,5 +1,3 @@
-
-
 import { useState } from "react";
 import BuscadorMaquina from "./BuscadorMaquina";
 import BuscadorTrabajador from "./BuscadorTrabajador";
@@ -117,6 +115,5 @@ export default function EditarAsignacion({ recursosIniciales, onClose, onSave })
         />
       )}
     </div>
-  </div>
  );
 }


### PR DESCRIPTION
## Summary
- remove `Referencia` from resource assignment table
- show machine and worker search with new modals
- use produced quantity value

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68895f0b40fc8325acf81c8922be5855