### PR TITLE
feat: add dashboard2 route with sidebar navigation

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -3,6 +3,7 @@ import Login from "./components/Login";
 import NuevaMinuta from "./pages/NuevaMinuta";
 import Signup from "./components/Signup";
 import Dashboard from "./pages/Dashboard";
+import Dashboard2 from "./pages/Dashboard2";
 import { AspectRatioProvider } from "./context/AspectRatioContext";
 import Alertas from "./pages/Alertas";
 import Navbar from "./components/Navbar";
@@ -33,6 +34,7 @@ function App() {
           <Route path="/login" element={<Login />} />
           <Route path="/register" element={<Signup />} />
           <Route path="/dashboard" element={<ProtectedLayout><Dashboard /></ProtectedLayout>} />
+          <Route path="/dashboard2" element={<ProtectedLayout><Dashboard2 /></ProtectedLayout>} />
           <Route path="/alertas" element={<ProtectedLayout><Alertas /></ProtectedLayout>} />
           <Route path="*" element={<ProtectedLayout><h1>Page not found</h1></ProtectedLayout>} />
           <Route path="/sesion/:id" element={<ProtectedLayout><Maquina /></ProtectedLayout>} />

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders nueva minuta heading', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const heading = screen.getByText(/nueva minuta/i);
+  expect(heading).toBeInTheDocument();
 });

--- a/src/pages/Dashboard2.js
+++ b/src/pages/Dashboard2.js
@@ -1,0 +1,140 @@
+import { useState, useEffect } from "react";
+import ProduccionChart from "../components/ProduccionChart";
+import ComponenteControl from "../components/ComponenteControl";
+import EstadisticasPanel from "../components/EstadisticasPanel";
+import AlertasComponent from "../components/AlertasComponent";
+
+function GeneralView() {
+  const [fechaHora, setFechaHora] = useState(new Date());
+
+  useEffect(() => {
+    const intervalo = setInterval(() => setFechaHora(new Date()), 1000);
+    return () => clearInterval(intervalo);
+  }, []);
+
+  return (
+    <div className="h-full overflow-y-auto p-6 space-y-6">
+      <div className="flex justify-between items-center mb-2">
+        <div className="font-semibold text-4xl">Resumen general</div>
+        <div className="text-sm text-gray-600">{fechaHora.toLocaleString()}</div>
+      </div>
+      <ProduccionChart />
+      <EstadisticasPanel />
+      <ComponenteControl />
+      <AlertasComponent />
+    </div>
+  );
+}
+
+function TrabajadoresMejores() {
+  return (
+    <div className="p-6 space-y-4 overflow-y-auto h-full">
+      <h2 className="text-2xl font-semibold">Comparativa de trabajadores</h2>
+      <div className="flex flex-wrap gap-4">
+        <div>
+          <label className="block mb-1">Área</label>
+          <select className="border rounded p-2">
+            <option>Área 1</option>
+            <option>Área 2</option>
+            <option>Área 3</option>
+          </select>
+        </div>
+        <div>
+          <label className="block mb-1">Métrica</label>
+          <select className="border rounded p-2">
+            <option>Producción</option>
+            <option>Eficiencia</option>
+            <option>Calidad</option>
+          </select>
+        </div>
+      </div>
+      <div className="mt-4 border rounded p-4 text-gray-500">
+        Aquí se mostrará la comparativa de trabajadores seleccionados.
+      </div>
+    </div>
+  );
+}
+
+function MaquinasMejores() {
+  return (
+    <div className="p-6 space-y-4 overflow-y-auto h-full">
+      <h2 className="text-2xl font-semibold">Comparativa de máquinas</h2>
+      <div className="flex flex-wrap gap-4">
+        <div>
+          <label className="block mb-1">Área</label>
+          <select className="border rounded p-2">
+            <option>Área 1</option>
+            <option>Área 2</option>
+            <option>Área 3</option>
+          </select>
+        </div>
+        <div>
+          <label className="block mb-1">Métrica</label>
+          <select className="border rounded p-2">
+            <option>Rendimiento</option>
+            <option>Disponibilidad</option>
+            <option>Uso</option>
+          </select>
+        </div>
+      </div>
+      <div className="mt-4 border rounded p-4 text-gray-500">
+        Aquí se mostrará la comparativa de máquinas seleccionadas.
+      </div>
+    </div>
+  );
+}
+
+export default function Dashboard2() {
+  const [view, setView] = useState("general");
+
+  let content;
+  switch (view) {
+    case "trabajadores":
+      content = <TrabajadoresMejores />;
+      break;
+    case "maquinas":
+      content = <MaquinasMejores />;
+      break;
+    default:
+      content = <GeneralView />;
+  }
+
+  return (
+    <div className="flex h-screen">
+      <aside className="w-64 bg-gray-100 border-r p-4 space-y-6">
+        <nav className="space-y-4">
+          <div>
+            <button
+              onClick={() => setView("general")}
+              className={`block w-full text-left p-2 rounded hover:bg-gray-200 ${view === "general" ? "bg-gray-200" : ""}`}
+            >
+              General
+            </button>
+          </div>
+          <div>
+            <div className="font-semibold text-gray-700 mb-2">Trabajadores</div>
+            <button
+              onClick={() => setView("trabajadores")}
+              className={`block w-full text-left p-2 rounded hover:bg-gray-200 ${view === "trabajadores" ? "bg-gray-200" : ""}`}
+            >
+              Ver mejores
+            </button>
+          </div>
+          <div>
+            <div className="font-semibold text-gray-700 mb-2">Máquina</div>
+            <button
+              onClick={() => setView("maquinas")}
+              className={`block w-full text-left p-2 rounded hover:bg-gray-200 ${view === "maquinas" ? "bg-gray-200" : ""}`}
+            >
+              Ver mejores
+            </button>
+          </div>
+        </nav>
+      </aside>
+      <main className="flex-1 overflow-hidden">
+        {content}
+      </main>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add `/dashboard2` route to access new dashboard
- create `Dashboard2` page with sidebar for general, trabajadores and máquina views
- update default test to check for "Nueva Minuta" heading

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68a5378aa8e88325b5f70bb73a9bab9c